### PR TITLE
Use lowercase in template logic to avoid 'Liquid Warnings'

### DIFF
--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -66,11 +66,11 @@
                         {% assign indicator_status = "Exploring Data" %}
                         {% assign status_label = "danger" %}
 
-                        {% if indicator.source_url != nil AND indicator.source_url != "" %}
+                        {% if indicator.source_url != nil and indicator.source_url != "" %}
                           {% assign indicator_status = "Compiling Statistics" %}
                           {% assign status_label = "warning" %}
 
-                          {% if indicator.graph != nil AND indicator.graph != "" %}
+                          {% if indicator.graph != nil and indicator.graph != "" %}
                             {% assign indicator_status = "Reported Online" %}
                             {% assign status_label = "success" %}
                           {% endif %}

--- a/_layouts/status.html
+++ b/_layouts/status.html
@@ -39,11 +39,11 @@
                     {% if indicator.un_designated_tier != '3' %}
                         {% assign unsourced_data = unsourced_data | plus:1 %}
 
-                        {% if indicator.source_url != nil AND indicator.source_url != "" %}
+                        {% if indicator.source_url != nil and indicator.source_url != "" %}
                           {% assign unsourced_data = unsourced_data | minus:1 %}
                           {% assign compiling_statistic = compiling_statistic | plus:1 %}
 
-                          {% if indicator.graph != nil AND indicator.graph != "" %}
+                          {% if indicator.graph != nil and indicator.graph != "" %}
                             {% assign compiling_statistic = compiling_statistic | minus:1 %}
                             {% assign finalized_reporting = finalized_reporting | plus:1 %}
                           {% endif %}
@@ -134,11 +134,11 @@
                             {% if indicator.un_designated_tier != '3' %}
                                 {% assign unsourced_data = unsourced_data | plus:1 %}
 
-                                {% if indicator.source_url != nil AND indicator.source_url != "" %}
+                                {% if indicator.source_url != nil and indicator.source_url != "" %}
                                   {% assign unsourced_data = unsourced_data | minus:1 %}
                                   {% assign compiling_statistic = compiling_statistic | plus:1 %}
 
-                                  {% if indicator.graph != nil AND indicator.graph != "" %}
+                                  {% if indicator.graph != nil and indicator.graph != "" %}
                                     {% assign compiling_statistic = compiling_statistic | minus:1 %}
                                     {% assign finalized_reporting = finalized_reporting | plus:1 %}
                                   {% endif %}


### PR DESCRIPTION
Currently there are "Liquid Warnings" that show up when running `jekyll serve` locally, and this fixes them. Apparently template logic operators like "and"/"or" need to be in lowercase.