### PR TITLE
Add a skip-link target for keyboard users

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -7,6 +7,7 @@
 
         <div id="main" class="main-content" role="main">
 
+            <a id="main-content" tabindex="-1"></a>
             <section class="usa-banner">
                 <div class="usa-grid">
 

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -11,7 +11,7 @@
 
       <div id="main" class="main-content initiative-content">
 
-
+        <a id="main-content" tabindex="-1"></a>
         <section class="usa-banner">
             <div class="usa-grid">
                 <div class="usa-banner-content">

--- a/_layouts/indicator-beta.html
+++ b/_layouts/indicator-beta.html
@@ -13,6 +13,7 @@
 
       <div id="main" class="main-content initiative-content">
 
+        <a id="main-content" tabindex="-1"></a>
         <section class="usa-banner">
             <div class="usa-grid">
                 <div class="usa-banner-content">

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -13,6 +13,7 @@
 
       <div id="main" class="main-content initiative-content">
 
+        <a id="main-content" tabindex="-1"></a>
         <section class="usa-banner">
             <div class="usa-grid">
                 <div class="usa-banner-content">

--- a/_layouts/initiative.html
+++ b/_layouts/initiative.html
@@ -4,7 +4,7 @@
 
         <div id="main" class="main-content initiative-content" role="main">            
             
-
+            <a id="main-content" tabindex="-1"></a>
             <section class="usa-banner">
                 <div class="usa-grid">
 

--- a/_layouts/initiatives.html
+++ b/_layouts/initiatives.html
@@ -5,6 +5,7 @@
 
         <div id="main" class="main-content" role="main">            
             
+            <a id="main-content" tabindex="-1"></a>
             <section class="usa-banner banner-small">
                 <div class="usa-grid">
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,6 +4,7 @@ layout: default
 
         <div id="main" class="main-content" role="main">
 
+            <a id="main-content" tabindex="-1"></a>
             <section class="usa-banner banner-small">
                 <div class="usa-grid">
 

--- a/_layouts/status.html
+++ b/_layouts/status.html
@@ -7,6 +7,7 @@
 
     <div id="main" class="main-content initiative-content status-dashboard">
 
+        <a id="main-content" tabindex="-1"></a>
         <section class="usa-banner banner-small">
             <div class="usa-grid">
                 <div class="usa-banner-content">


### PR DESCRIPTION
There is a "skip link" currently which appears when the user hits TAB, but it has nowhere to link to when the user hits ENTER. This adds an anchor which the skip links can target, allowing keyboard users to bypass the header navigation.