### PR TITLE
Allow for external indicator data sources at run-time

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,12 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       lang: en
+  -
+    scope:
+      layout: "indicator"
+    values:
+      # This value corresponds to a file in _includes/indicator_data_source/.
+      indicator_data_source: local_csv
 
 analytics:
   ga_prod: 'UA-42145528-4'

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -37,6 +37,12 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       lang: en
+  -
+    scope:
+      layout: "indicator"
+    values:
+      # This value corresponds to a file in _includes/indicator_data_source/.
+      indicator_data_source: local_csv
 
 analytics:
   ga_prod: 'UA-42145528-4'

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -37,6 +37,12 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       lang: en
+  -
+    scope:
+      layout: "indicator"
+    values:
+      # This value corresponds to a file in _includes/indicator_data_source/.
+      indicator_data_source: local_csv
 
 # Prose configuration
 prose: 

--- a/_includes/components/bar-rate.html
+++ b/_includes/components/bar-rate.html
@@ -5,10 +5,8 @@
 {% endif %}
 
 <script>
-  (function () {
+  function indicatorGraphBarRate(labels, row) {
     var container = '#chart-{{ id }}'
-    var labels = {{ include.labels | jsonify }}
-    var row = {{ include.row | jsonify }}
 
     // Construct array of objects from data using indicators
     var series = labels.map(function (col) {
@@ -51,5 +49,5 @@
       ]
     }
     new Chartist.Bar(container, chartData, chartOpts)
-  })()
+  };
 </script>

--- a/_includes/components/bar-rate.html
+++ b/_includes/components/bar-rate.html
@@ -1,9 +1,12 @@
 {% assign id = include.row.Indicator | slugify %}
 {% if page.title == 'Top 10 Cities' %} 
-  <div id="chart-{{ id }}" class="ct-chart ct-major-seventh"></div>{% else %}  
-  <div id="chart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
+  <div id="chart-{{ id }}" class="ct-chart ct-major-seventh">
+    <div class="spin"></div>
+  </div>{% else %}
+  <div id="chart-{{ id }}" class="ct-chart ct-major-eleventh">
+    <div class="spin"></div>
+  </div>
 {% endif %}
-
 <script>
   var sdg_indicators = sdg_indicators || {};
   sdg_indicators.indicatorGraphBarRate = function(labels, row) {

--- a/_includes/components/bar-rate.html
+++ b/_includes/components/bar-rate.html
@@ -5,7 +5,8 @@
 {% endif %}
 
 <script>
-  function indicatorGraphBarRate(labels, row) {
+  var sdg_indicators = sdg_indicators || {};
+  sdg_indicators.indicatorGraphBarRate = function(labels, row) {
     var container = '#chart-{{ id }}'
 
     // Construct array of objects from data using indicators

--- a/_includes/components/bar.html
+++ b/_includes/components/bar.html
@@ -2,7 +2,8 @@
 {% assign unit_label = page.variable_unit_label %}
 <div id="barchart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
 <script>
-function indicatorGraphBar(labels, row) {
+var sdg_indicators = sdg_indicators || {};
+sdg_indicators.indicatorGraphBar = function(labels, row) {
   var container = '#barchart-{{ id }}'
 
   // Construct array of objects from data using indicators

--- a/_includes/components/bar.html
+++ b/_includes/components/bar.html
@@ -1,6 +1,8 @@
 {% assign id = page.indicator | slugify %}
 {% assign unit_label = page.variable_unit_label %}
-<div id="barchart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
+<div id="barchart-{{ id }}" class="ct-chart ct-major-eleventh">
+  <div class="spin"></div>
+</div>
 <script>
 var sdg_indicators = sdg_indicators || {};
 sdg_indicators.indicatorGraphBar = function(labels, row) {

--- a/_includes/components/bar.html
+++ b/_includes/components/bar.html
@@ -2,10 +2,8 @@
 {% assign unit_label = page.variable_unit_label %}
 <div id="barchart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
 <script>
-(function () {
+function indicatorGraphBar(labels, row) {
   var container = '#barchart-{{ id }}'
-  var labels = {{ include.labels | jsonify }}
-  var row = {{ include.row | jsonify }}
 
   // Construct array of objects from data using indicators
   var series = row
@@ -58,5 +56,5 @@
   }
 });
 
-  })()
+};
 </script>

--- a/_includes/components/binary.html
+++ b/_includes/components/binary.html
@@ -14,7 +14,9 @@
   {% endcase %}
 {% endfor %}
 
-<div id="binary-chart-{{ id }}" class="ct-chart ct-chart-binary ct-major-eleventh"></div>
+<div id="binary-chart-{{ id }}" class="ct-chart ct-chart-binary ct-major-eleventh">
+  <div class="spin"></div>
+</div>
 <script>
 var sdg_indicators = sdg_indicators || {};
 sdg_indicators.indicatorGraphBinary = function(labels, row) {

--- a/_includes/components/binary.html
+++ b/_includes/components/binary.html
@@ -16,7 +16,8 @@
 
 <div id="binary-chart-{{ id }}" class="ct-chart ct-chart-binary ct-major-eleventh"></div>
 <script>
-function indicatorGraphBinary(labels, row) {
+var sdg_indicators = sdg_indicators || {};
+sdg_indicators.indicatorGraphBinary = function(labels, row) {
   var container = '#binary-chart-{{ id }}'
 
   // Construct array of objects from data using indicators

--- a/_includes/components/binary.html
+++ b/_includes/components/binary.html
@@ -16,10 +16,8 @@
 
 <div id="binary-chart-{{ id }}" class="ct-chart ct-chart-binary ct-major-eleventh"></div>
 <script>
-(function () {
+function indicatorGraphBinary(labels, row) {
   var container = '#binary-chart-{{ id }}'
-  var labels = {{ include.labels | jsonify }}
-  var series = {{ row_transform | jsonify }}
 
   // Construct array of objects from data using indicators
   var chartData = {
@@ -51,5 +49,5 @@
     }
   new Chartist.Bar(container, chartData, chartOpts).on('draw', function(data) {});
 
-  })()
+  };
 </script>

--- a/_includes/components/line-rate.html
+++ b/_includes/components/line-rate.html
@@ -1,10 +1,8 @@
 {% assign id = include.row.Indicator | slugify %}
 <div id="chart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
 <script>
-(function () {
+function indicatorGraphLineRate(labels, row) {
   var container = '#chart-{{ id }}'
-  var labels = {{ include.labels | jsonify }}
-  var row = {{ include.row | jsonify }}
 
   // Construct array of objects from data using indicators
   var series = labels.map(function (col) {
@@ -45,5 +43,5 @@
     ],
   }
   new Chartist.Line(container, chartData, chartOpts)
-})()
+};
 </script>

--- a/_includes/components/line-rate.html
+++ b/_includes/components/line-rate.html
@@ -1,5 +1,7 @@
 {% assign id = include.row.Indicator | slugify %}
-<div id="chart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
+<div id="chart-{{ id }}" class="ct-chart ct-major-eleventh">
+  <div class="spin"></div>
+</div>
 <script>
 var sdg_indicators = sdg_indicators || {};
 sdg_indicators.indicatorGraphLineRate = function(labels, row) {

--- a/_includes/components/line-rate.html
+++ b/_includes/components/line-rate.html
@@ -1,7 +1,8 @@
 {% assign id = include.row.Indicator | slugify %}
 <div id="chart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
 <script>
-function indicatorGraphLineRate(labels, row) {
+var sdg_indicators = sdg_indicators || {};
+sdg_indicators.indicatorGraphLineRate = function(labels, row) {
   var container = '#chart-{{ id }}'
 
   // Construct array of objects from data using indicators

--- a/_includes/components/line.html
+++ b/_includes/components/line.html
@@ -2,10 +2,8 @@
 {% assign unit_label = page.variable_unit_label %}
 <div id="linechart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
 <script>
-(function () {
+function indicatorGraphLine(labels, row) {
   var container = '#linechart-{{ id }}'
-  var labels = {{ include.labels | jsonify }}
-  var row = {{ include.row | jsonify }}
 
   // Construct array of objects from data using indicators
   var series = row
@@ -52,5 +50,5 @@
     ],
   }
   new Chartist.Line(container, chartData, chartOpts)
-})()
+};
 </script>

--- a/_includes/components/line.html
+++ b/_includes/components/line.html
@@ -1,6 +1,8 @@
 {% assign id = page.indicator | slugify %}
 {% assign unit_label = page.variable_unit_label %}
-<div id="linechart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
+<div id="linechart-{{ id }}" class="ct-chart ct-major-eleventh">
+  <div class="spin"></div>
+</div>
 <script>
 var sdg_indicators = sdg_indicators || {};
 sdg_indicators.indicatorGraphLine = function(labels, row) {

--- a/_includes/components/line.html
+++ b/_includes/components/line.html
@@ -2,7 +2,8 @@
 {% assign unit_label = page.variable_unit_label %}
 <div id="linechart-{{ id }}" class="ct-chart ct-major-eleventh"></div>
 <script>
-function indicatorGraphLine(labels, row) {
+var sdg_indicators = sdg_indicators || {};
+sdg_indicators.indicatorGraphLine = function(labels, row) {
   var container = '#linechart-{{ id }}'
 
   // Construct array of objects from data using indicators

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -30,6 +30,9 @@
   <script src="/assets/js/vendor/respond.js"></script>
   <script src="/assets/js/vendor/selectivizr-min.js"></script>
 <![endif]-->
+        <!--[if IE]>
+          <script src="{{ site.baseurl }}/assets/js/vendor/custom-event-polyfill.js"></script>
+        <![endif]-->
         <!-- Favicons
 ================================================== -->
         <!-- 128x128 -->

--- a/_includes/indicator_data_source/base.html
+++ b/_includes/indicator_data_source/base.html
@@ -13,12 +13,13 @@ $('.spin').show();
 // be overridden by any data source implementation.
 document.addEventListener('IndicatorDataReady', function(e) {
   sdg_indicators.indicatorTableAdapter(e);
+
   {% case include.graph_type %}
-    {% when 'line' %} sdg_indicators.indicatorGraphLineAdapter(e);
-    {% when 'line-rate' %} sdg_indicators.indicatorGraphLineRateAdapter(e);
-    {% when 'bar' %} sdg_indicators.indicatorGraphBarAdapter(e);
-    {% when 'bar-rate' %} sdg_indicators.indicatorGraphBarRateAdapter(e);
-    {% when 'binary' %} sdg_indicators.indicatorGraphBinaryAdapter(e);
+  {% when 'line' %} sdg_indicators.indicatorGraphLineAdapter(e);
+  {% when 'line-rate' %} sdg_indicators.indicatorGraphLineRateAdapter(e);
+  {% when 'bar' %} sdg_indicators.indicatorGraphBarAdapter(e);
+  {% when 'bar-rate' %} sdg_indicators.indicatorGraphBarRateAdapter(e);
+  {% when 'binary' %} sdg_indicators.indicatorGraphBinaryAdapter(e);
   {% endcase %}
 
   // Turn off spinners now that the data source has responded.

--- a/_includes/indicator_data_source/base.html
+++ b/_includes/indicator_data_source/base.html
@@ -1,5 +1,9 @@
 <script type="text/javascript">
 
+/**
+ * Base code needed for all implementations of indicator data sources.
+ */
+
 var sdg_indicators = sdg_indicators || {};
 
 // Turn on spinners in case the data source takes a long time.

--- a/_includes/indicator_data_source/base.html
+++ b/_includes/indicator_data_source/base.html
@@ -1,0 +1,24 @@
+<script type="text/javascript">
+
+var sdg_indicators = sdg_indicators || {};
+
+// Stub functions for each type of data visualization. Each of these should be
+// overridden for any implementation of an indicator data source.
+sdg_indicators.renderTable = function(e) { throw "renderTable not implemented." };
+sdg_indicators.renderLine = function(e) { throw "renderLine not implemented." };
+sdg_indicators.renderLineRate = function(e) { throw "renderLineRate not implemented." };
+sdg_indicators.renderBar = function(e) { throw "renderBar not implemented." };
+sdg_indicators.renderBarRate = function(e) { throw "renderBarRate not implemented." };
+sdg_indicators.renderBinary = function(e) { throw "renderBinary not implemented." };
+
+// Event listener for whenever the data comes back.
+document.addEventListener('IndicatorDataReady', function(e) {
+  sdg_indicators.renderTable(e);
+  sdg_indicators.renderLine(e);
+  sdg_indicators.renderLineRate(e);
+  sdg_indicators.renderBar(e);
+  sdg_indicators.renderBarRate(e);
+  sdg_indicators.renderBinary(e);
+}, false);
+
+</script>

--- a/_includes/indicator_data_source/base.html
+++ b/_includes/indicator_data_source/base.html
@@ -2,23 +2,23 @@
 
 var sdg_indicators = sdg_indicators || {};
 
-// Stub functions for each type of data visualization. Each of these should be
-// overridden for any implementation of an indicator data source.
-sdg_indicators.indicatorTableAdapter = function(e) { throw "indicatorTableAdapter not implemented." };
-sdg_indicators.indicatorGraphLineAdapter = function(e) { throw "indicatorGraphLineAdapter not implemented." };
-sdg_indicators.indicatorGraphLineRateAdapter = function(e) { throw "indicatorGraphLineRateAdapter not implemented." };
-sdg_indicators.indicatorGraphBarAdapter = function(e) { throw "indicatorGraphBarAdapter not implemented." };
-sdg_indicators.indicatorGraphBarRateAdapter = function(e) { throw "indicatorGraphBarRateAdapter not implemented." };
-sdg_indicators.indicatorGraphBinaryAdapter = function(e) { throw "indicatorGraphBinaryAdapter not implemented." };
+// Turn on spinners in case the data source takes a long time.
+$('.spin').show();
 
-// Event listener for whenever the data comes back.
+// Event listener for whenever the data comes back. The following methods should
+// be overridden by any data source implementation.
 document.addEventListener('IndicatorDataReady', function(e) {
   sdg_indicators.indicatorTableAdapter(e);
-  sdg_indicators.indicatorGraphLineAdapter(e);
-  sdg_indicators.indicatorGraphLineRateAdapter(e);
-  sdg_indicators.indicatorGraphBarAdapter(e);
-  sdg_indicators.indicatorGraphBarRateAdapter(e);
-  sdg_indicators.indicatorGraphBinaryAdapter(e);
+  {% case include.graph_type %}
+    {% when 'line' %} sdg_indicators.indicatorGraphLineAdapter(e);
+    {% when 'line-rate' %} sdg_indicators.indicatorGraphLineRateAdapter(e);
+    {% when 'bar' %} sdg_indicators.indicatorGraphBarAdapter(e);
+    {% when 'bar-rate' %} sdg_indicators.indicatorGraphBarRateAdapter(e);
+    {% when 'binary' %} sdg_indicators.indicatorGraphBinaryAdapter(e);
+  {% endcase %}
+
+  // Turn off spinners now that the data source has responded.
+  $('.spin').hide();
 }, false);
 
 </script>

--- a/_includes/indicator_data_source/base.html
+++ b/_includes/indicator_data_source/base.html
@@ -4,21 +4,21 @@ var sdg_indicators = sdg_indicators || {};
 
 // Stub functions for each type of data visualization. Each of these should be
 // overridden for any implementation of an indicator data source.
-sdg_indicators.renderTable = function(e) { throw "renderTable not implemented." };
-sdg_indicators.renderLine = function(e) { throw "renderLine not implemented." };
-sdg_indicators.renderLineRate = function(e) { throw "renderLineRate not implemented." };
-sdg_indicators.renderBar = function(e) { throw "renderBar not implemented." };
-sdg_indicators.renderBarRate = function(e) { throw "renderBarRate not implemented." };
-sdg_indicators.renderBinary = function(e) { throw "renderBinary not implemented." };
+sdg_indicators.indicatorTableAdapter = function(e) { throw "indicatorTableAdapter not implemented." };
+sdg_indicators.indicatorGraphLineAdapter = function(e) { throw "indicatorGraphLineAdapter not implemented." };
+sdg_indicators.indicatorGraphLineRateAdapter = function(e) { throw "indicatorGraphLineRateAdapter not implemented." };
+sdg_indicators.indicatorGraphBarAdapter = function(e) { throw "indicatorGraphBarAdapter not implemented." };
+sdg_indicators.indicatorGraphBarRateAdapter = function(e) { throw "indicatorGraphBarRateAdapter not implemented." };
+sdg_indicators.indicatorGraphBinaryAdapter = function(e) { throw "indicatorGraphBinaryAdapter not implemented." };
 
 // Event listener for whenever the data comes back.
 document.addEventListener('IndicatorDataReady', function(e) {
-  sdg_indicators.renderTable(e);
-  sdg_indicators.renderLine(e);
-  sdg_indicators.renderLineRate(e);
-  sdg_indicators.renderBar(e);
-  sdg_indicators.renderBarRate(e);
-  sdg_indicators.renderBinary(e);
+  sdg_indicators.indicatorTableAdapter(e);
+  sdg_indicators.indicatorGraphLineAdapter(e);
+  sdg_indicators.indicatorGraphLineRateAdapter(e);
+  sdg_indicators.indicatorGraphBarAdapter(e);
+  sdg_indicators.indicatorGraphBarRateAdapter(e);
+  sdg_indicators.indicatorGraphBinaryAdapter(e);
 }, false);
 
 </script>

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -55,8 +55,7 @@ var sdg_indicators = sdg_indicators || {};
   };
   {% endcase %}
 
-  // Now that all the methods are overridden, prepare some Jekyll data to pass
-  // into the custom event.
+  // Prepare some Jekyll data to pass into the custom event.
   {% assign slug = page.indicator | replace: '.', '-' %}
   {% assign dataset_name = 'indicator_' | append: slug %}
 

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -15,6 +15,12 @@ var sdg_indicators = sdg_indicators || {};
       csv_options: {separator: ',', delimiter: '"'},
       datatables_options: {"paging": false, "bInfo" : false, "searching": false}
     });
+    // Add the download button.
+    var $button = $('<a/>')
+      .addClass('usa-button usa-button-big')
+      .attr('href', e.detail.csv_path)
+      .text('Download CSV');
+    $('.datatable-container .button_wrapper').append($button);
   };
 
   // Override the indicatorGraphLineAdapter method.

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -1,0 +1,83 @@
+<script type="text/javascript">
+
+var sdg_indicators = sdg_indicators || {};
+
+(function() {
+
+  // Override the renderTable method.
+  sdg_indicators.renderTable = function(e) {
+    // Use the assets/js/vendor/csv_to_html_table.js library to render the CSV
+    // as an HTML table.
+    init_table({
+      csv_path: e.detail.csv_path,
+      element: 'datatable',
+      allow_download: false,
+      csv_options: {separator: ',', delimiter: '"'},
+      datatables_options: {"paging": false, "bInfo" : false, "searching": false}
+    });
+  };
+
+  // Override the renderLine method.
+  sdg_indicators.renderLine = function(e) {
+    if (typeof indicatorGraphLine === 'function') {
+      indicatorGraphLine(e.detail.labels, e.detail.row);
+    }
+  };
+
+  // Override the renderLineRate method.
+  sdg_indicators.renderLineRate = function(e) {
+    if (typeof indicatorGraphLineRate === 'function') {
+      indicatorGraphLineRate(e.detail.labels, e.detail.row);
+    }
+  };
+
+  // Override the renderBar method.
+  sdg_indicators.renderBar = function(e) {
+    if (typeof indicatorGraphBar === 'function') {
+      indicatorGraphBar(e.detail.labels, e.detail.row);
+    }
+  };
+
+  // Override the renderBarRate method.
+  sdg_indicators.renderBarRate = function(e) {
+    if (typeof indicatorBarRate === 'function') {
+      indicatorGraphBarRate(e.detail.labels, e.detail.row);
+    }
+  };
+
+  // Override the renderBinary method.
+  sdg_indicators.renderBinary = function(e) {
+    if (typeof indicatorGraphBinary === 'function') {
+      indicatorGraphBinary(e.detail.labels, e.detail.row);
+    }
+  };
+
+  // Now that all the methods are overridden, prepare some data and then emit
+  // the custom "IndicatorDataReady" event.
+  {% assign slug = page.indicator | replace: '.', '-' %}
+  {% assign dataset_name = 'indicator_' | append: slug %}
+
+  {% assign array = "" | split: ""  %}
+  {% assign row = array %}
+  {% assign labels = array %}
+
+  {% for indicator in site.data[dataset_name] %}
+    {% assign row = row | push: indicator[page.indicator_variable] %}
+    {% assign labels = labels | push: indicator.year %}
+  {% endfor %}
+
+  var row = {{ row | jsonify }};
+  var labels = {{ labels | jsonify }};
+
+  var csv_path =  '{{ site.baseurl }}/data/{{ dataset_name }}.csv';
+  var event = new CustomEvent('IndicatorDataReady', {
+    detail: {
+      row: row,
+      labels: labels,
+      csv_path: csv_path
+    }
+  });
+  document.dispatchEvent(event);
+})();
+
+</script>

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -1,5 +1,9 @@
 <script type="text/javascript">
 
+/**
+ * An implementation of a data source for indicator data using local CSV files.
+ */
+
 var sdg_indicators = sdg_indicators || {};
 
 (function() {

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -31,27 +31,27 @@ var sdg_indicators = sdg_indicators || {};
   {% when 'line' %}
   // Implement the indicatorGraphLineAdapter method.
   sdg_indicators.indicatorGraphLineAdapter = function(e) {
-      sdg_indicators.indicatorGraphLine(e.detail.labels, e.detail.row);
+    sdg_indicators.indicatorGraphLine(e.detail.labels, e.detail.row);
   };
   {% when 'line-rate' %}
   // Implement the indicatorGraphLineRateAdapter method.
   sdg_indicators.indicatorGraphLineRateAdapter = function(e) {
-      sdg_indicators.indicatorGraphLineRate(e.detail.labels, e.detail.row);
+    sdg_indicators.indicatorGraphLineRate(e.detail.labels, e.detail.row);
   };
   {% when 'bar' %}
   // Implement the indicatorGraphBarAdapter method.
   sdg_indicators.indicatorGraphBarAdapter = function(e) {
-      sdg_indicators.indicatorGraphBar(e.detail.labels, e.detail.row);
+    sdg_indicators.indicatorGraphBar(e.detail.labels, e.detail.row);
   };
   {% when 'bar-rate' %}
   // Implement the indicatorGraphBarRateAdapter method.
   sdg_indicators.indicatorGraphBarRateAdapter = function(e) {
-      sdg_indicators.indicatorGraphBarRate(e.detail.labels, e.detail.row);
+    sdg_indicators.indicatorGraphBarRate(e.detail.labels, e.detail.row);
   };
   {% when 'binary' %}
   // Implement the indicatorGraphBinaryAdapter method.
   sdg_indicators.indicatorGraphBinaryAdapter = function(e) {
-      sdg_indicators.indicatorGraphBinary(e.detail.labels, e.detail.row);
+    sdg_indicators.indicatorGraphBinary(e.detail.labels, e.detail.row);
   };
   {% endcase %}
 

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -4,7 +4,7 @@ var sdg_indicators = sdg_indicators || {};
 
 (function() {
 
-  // Override the indicatorTableAdapter method.
+  // Implement the indicatorTableAdapter method.
   sdg_indicators.indicatorTableAdapter = function(e) {
     // Use the assets/js/vendor/csv_to_html_table.js library to render the CSV
     // as an HTML table.
@@ -23,40 +23,33 @@ var sdg_indicators = sdg_indicators || {};
     $('.datatable-container .button_wrapper').append($button);
   };
 
-  // Override the indicatorGraphLineAdapter method.
+  {% case include.graph_type %}
+    {% when 'line' %}
+    // Implement the indicatorGraphLineAdapter method.
   sdg_indicators.indicatorGraphLineAdapter = function(e) {
-    if (sdg_indicators.indicatorGraphLine) {
       sdg_indicators.indicatorGraphLine(e.detail.labels, e.detail.row);
-    }
   };
-
-  // Override the indicatorGraphLineRateAdapter method.
+    {% when 'line-rate' %}
+    // Implement the indicatorGraphLineRateAdapter method.
   sdg_indicators.indicatorGraphLineRateAdapter = function(e) {
-    if (sdg_indicators.indicatorGraphLineRate) {
       sdg_indicators.indicatorGraphLineRate(e.detail.labels, e.detail.row);
-    }
   };
-
-  // Override the indicatorGraphBarAdapter method.
+    {% when 'bar' %}
+    // Implement the indicatorGraphBarAdapter method.
   sdg_indicators.indicatorGraphBarAdapter = function(e) {
-    if (sdg_indicators.indicatorGraphBar) {
       sdg_indicators.indicatorGraphBar(e.detail.labels, e.detail.row);
-    }
   };
-
-  // Override the indicatorGraphBarRateAdapter method.
+    {% when 'bar-rate' %}
+    // Implement the indicatorGraphBarRateAdapter method.
   sdg_indicators.indicatorGraphBarRateAdapter = function(e) {
-    if (sdg_indicators.indicatorGraphBarRate) {
       sdg_indicators.indicatorGraphBarRate(e.detail.labels, e.detail.row);
-    }
   };
-
-  // Override the indicatorGraphBinaryAdapter method.
+    {% when 'binary' %}
+    // Implement the indicatorGraphBinaryAdapter method.
   sdg_indicators.indicatorGraphBinaryAdapter = function(e) {
-    if (sdg_indicators.indicatorGraphBinary) {
       sdg_indicators.indicatorGraphBinary(e.detail.labels, e.detail.row);
-    }
   };
+  {% endcase %}
 
   // Now that all the methods are overridden, prepare some Jekyll data to pass
   // into the custom event.

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -28,28 +28,28 @@ var sdg_indicators = sdg_indicators || {};
   };
 
   {% case include.graph_type %}
-    {% when 'line' %}
-    // Implement the indicatorGraphLineAdapter method.
+  {% when 'line' %}
+  // Implement the indicatorGraphLineAdapter method.
   sdg_indicators.indicatorGraphLineAdapter = function(e) {
       sdg_indicators.indicatorGraphLine(e.detail.labels, e.detail.row);
   };
-    {% when 'line-rate' %}
-    // Implement the indicatorGraphLineRateAdapter method.
+  {% when 'line-rate' %}
+  // Implement the indicatorGraphLineRateAdapter method.
   sdg_indicators.indicatorGraphLineRateAdapter = function(e) {
       sdg_indicators.indicatorGraphLineRate(e.detail.labels, e.detail.row);
   };
-    {% when 'bar' %}
-    // Implement the indicatorGraphBarAdapter method.
+  {% when 'bar' %}
+  // Implement the indicatorGraphBarAdapter method.
   sdg_indicators.indicatorGraphBarAdapter = function(e) {
       sdg_indicators.indicatorGraphBar(e.detail.labels, e.detail.row);
   };
-    {% when 'bar-rate' %}
-    // Implement the indicatorGraphBarRateAdapter method.
+  {% when 'bar-rate' %}
+  // Implement the indicatorGraphBarRateAdapter method.
   sdg_indicators.indicatorGraphBarRateAdapter = function(e) {
       sdg_indicators.indicatorGraphBarRate(e.detail.labels, e.detail.row);
   };
-    {% when 'binary' %}
-    // Implement the indicatorGraphBinaryAdapter method.
+  {% when 'binary' %}
+  // Implement the indicatorGraphBinaryAdapter method.
   sdg_indicators.indicatorGraphBinaryAdapter = function(e) {
       sdg_indicators.indicatorGraphBinary(e.detail.labels, e.detail.row);
   };

--- a/_includes/indicator_data_source/local_csv.html
+++ b/_includes/indicator_data_source/local_csv.html
@@ -4,8 +4,8 @@ var sdg_indicators = sdg_indicators || {};
 
 (function() {
 
-  // Override the renderTable method.
-  sdg_indicators.renderTable = function(e) {
+  // Override the indicatorTableAdapter method.
+  sdg_indicators.indicatorTableAdapter = function(e) {
     // Use the assets/js/vendor/csv_to_html_table.js library to render the CSV
     // as an HTML table.
     init_table({
@@ -17,43 +17,43 @@ var sdg_indicators = sdg_indicators || {};
     });
   };
 
-  // Override the renderLine method.
-  sdg_indicators.renderLine = function(e) {
-    if (typeof indicatorGraphLine === 'function') {
-      indicatorGraphLine(e.detail.labels, e.detail.row);
+  // Override the indicatorGraphLineAdapter method.
+  sdg_indicators.indicatorGraphLineAdapter = function(e) {
+    if (sdg_indicators.indicatorGraphLine) {
+      sdg_indicators.indicatorGraphLine(e.detail.labels, e.detail.row);
     }
   };
 
-  // Override the renderLineRate method.
-  sdg_indicators.renderLineRate = function(e) {
-    if (typeof indicatorGraphLineRate === 'function') {
-      indicatorGraphLineRate(e.detail.labels, e.detail.row);
+  // Override the indicatorGraphLineRateAdapter method.
+  sdg_indicators.indicatorGraphLineRateAdapter = function(e) {
+    if (sdg_indicators.indicatorGraphLineRate) {
+      sdg_indicators.indicatorGraphLineRate(e.detail.labels, e.detail.row);
     }
   };
 
-  // Override the renderBar method.
-  sdg_indicators.renderBar = function(e) {
-    if (typeof indicatorGraphBar === 'function') {
-      indicatorGraphBar(e.detail.labels, e.detail.row);
+  // Override the indicatorGraphBarAdapter method.
+  sdg_indicators.indicatorGraphBarAdapter = function(e) {
+    if (sdg_indicators.indicatorGraphBar) {
+      sdg_indicators.indicatorGraphBar(e.detail.labels, e.detail.row);
     }
   };
 
-  // Override the renderBarRate method.
-  sdg_indicators.renderBarRate = function(e) {
-    if (typeof indicatorBarRate === 'function') {
-      indicatorGraphBarRate(e.detail.labels, e.detail.row);
+  // Override the indicatorGraphBarRateAdapter method.
+  sdg_indicators.indicatorGraphBarRateAdapter = function(e) {
+    if (sdg_indicators.indicatorGraphBarRate) {
+      sdg_indicators.indicatorGraphBarRate(e.detail.labels, e.detail.row);
     }
   };
 
-  // Override the renderBinary method.
-  sdg_indicators.renderBinary = function(e) {
-    if (typeof indicatorGraphBinary === 'function') {
-      indicatorGraphBinary(e.detail.labels, e.detail.row);
+  // Override the indicatorGraphBinaryAdapter method.
+  sdg_indicators.indicatorGraphBinaryAdapter = function(e) {
+    if (sdg_indicators.indicatorGraphBinary) {
+      sdg_indicators.indicatorGraphBinary(e.detail.labels, e.detail.row);
     }
   };
 
-  // Now that all the methods are overridden, prepare some data and then emit
-  // the custom "IndicatorDataReady" event.
+  // Now that all the methods are overridden, prepare some Jekyll data to pass
+  // into the custom event.
   {% assign slug = page.indicator | replace: '.', '-' %}
   {% assign dataset_name = 'indicator_' | append: slug %}
 
@@ -66,18 +66,14 @@ var sdg_indicators = sdg_indicators || {};
     {% assign labels = labels | push: indicator.year %}
   {% endfor %}
 
-  var row = {{ row | jsonify }};
-  var labels = {{ labels | jsonify }};
-
-  var csv_path =  '{{ site.baseurl }}/data/{{ dataset_name }}.csv';
-  var event = new CustomEvent('IndicatorDataReady', {
+  // Finally emit the custom event.
+  document.dispatchEvent(new CustomEvent('IndicatorDataReady', {
     detail: {
-      row: row,
-      labels: labels,
-      csv_path: csv_path
+      row: {{ row | jsonify }},
+      labels: {{ labels | jsonify }},
+      csv_path: '{{ site.baseurl }}/data/{{ dataset_name }}.csv'
     }
-  });
-  document.dispatchEvent(event);
+  }));
 })();
 
 </script>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -96,6 +96,7 @@
 
       <div class="datatable-container">
         <h4>{{ page.graph_title }}</h4>
+        <div class="spin"></div>
         <div id="datatable"></div>
         <div class="button_wrapper"></div>
       </div>
@@ -216,7 +217,7 @@
 
 {% include scripts.html %}
 
-{% include indicator_data_source/base.html %}
-{% include indicator_data_source/{{ page.indicator_data_source }}.html metadata=this_sdg_indicator_metadata %}
+{% include indicator_data_source/base.html graph_type=graph_type %}
+{% include indicator_data_source/{{ page.indicator_data_source }}.html graph_type=graph_type %}
     
 {% include footer.html %}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -97,14 +97,7 @@
       <div class="datatable-container">
         <h4>{{ page.graph_title }}</h4>
         <div id="datatable"></div>
-
-
-          <div class="button_wrapper">
-              <a class="usa-button usa-button-big" href="{{ site.baseurl }}/data/{{ dataset_name }}.csv">Download CSV</a>
-          </div>
-        
-
-
+        <div class="button_wrapper"></div>
       </div>
       {% else %}
 

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -51,8 +51,6 @@
     {% assign page = site.indicators | where:"indicator", page.indicator  | first %}
 {% endif %}
 
-{% assign sdg_indicator = site.data[dataset_name] %}
-
 {% for indicators in sdg_indicators %}
 {% if indicators.indicator_id == page.indicator %}
   {% assign this_sdg_indicator_metadata = indicators %}  
@@ -60,16 +58,6 @@
 {% endfor %}
 
 {% assign indicator_title = this_sdg_indicator_metadata.indicator %}
-
-{% assign array = "" | split: ""  %}
-{% assign row = array %}
-{% assign labels = array %}
-
-{% for indicator in sdg_indicator %}
-  {% assign row = row | push: indicator[page.indicator_variable] %}
-  {% assign labels = labels | push: indicator.year %}
-{% endfor %}
-
 
 <h3>{{ t.sub-subtitle }} {{ page.indicator }} - {{ indicator_title }}</h3>
 
@@ -84,7 +72,7 @@
 {% assign graph_template = 'components/' | append: graph_type | append: '.html' %}
 
   <h4>{{ page.graph_title }}</h4>
-  {% include {{graph_template}} row=row labels=labels %}
+  {% include {{graph_template}} %}
 {% endif %}
 
 {{ page.content }}
@@ -235,14 +223,7 @@
 
 {% include scripts.html %}
 
-<script>
-  init_table({
-    csv_path: '{{ site.baseurl }}/data/{{ dataset_name }}.csv', 
-    element: 'datatable', 
-    allow_download: false,
-    csv_options: {separator: ',', delimiter: '"'},
-    datatables_options: {"paging": false, "bInfo" : false, "searching": false}
-  });
-</script>
+{% include indicator_data_source/base.html %}
+{% include indicator_data_source/{{ page.indicator_data_source }}.html metadata=this_sdg_indicator_metadata %}
     
 {% include footer.html %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -597,3 +597,19 @@ margin-bottom : 1em;
 .status-dashboard .goal-progress .usa-grid-full .media-object {
     max-width: 155px;
 }
+
+.spin {
+    margin: 0 auto;
+    border: 16px solid #f3f3f3; /* Light grey */
+    border-top: 16px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 120px;
+    height: 120px;
+    animation: spin 2s linear infinite;
+    display: none;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/assets/js/vendor/custom-event-polyfill.js
+++ b/assets/js/vendor/custom-event-polyfill.js
@@ -1,0 +1,44 @@
+// Polyfill for creating CustomEvents on IE9/10/11
+
+// code pulled from:
+// https://github.com/d4tocchini/customevent-polyfill
+// https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#Polyfill
+
+try {
+    var ce = new window.CustomEvent('test');
+    ce.preventDefault();
+    if (ce.defaultPrevented !== true) {
+        // IE has problems with .preventDefault() on custom events
+        // http://stackoverflow.com/questions/23349191
+        throw new Error('Could not prevent default');
+    }
+} catch(e) {
+  var CustomEvent = function(event, params) {
+    var evt, origPrevent;
+    params = params || {
+      bubbles: false,
+      cancelable: false,
+      detail: undefined
+    };
+
+    evt = document.createEvent("CustomEvent");
+    evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+    origPrevent = evt.preventDefault;
+    evt.preventDefault = function () {
+      origPrevent.call(this);
+      try {
+        Object.defineProperty(this, 'defaultPrevented', {
+          get: function () {
+            return true;
+          }
+        });
+      } catch(e) {
+        this.defaultPrevented = true;
+      }
+    };
+    return evt;
+  };
+
+  CustomEvent.prototype = window.Event.prototype;
+  window.CustomEvent = CustomEvent; // expose definition to window
+}


### PR DESCRIPTION
This update is meant to allow for the possibility of external data sources at run-time. It should not visibly change anything, but it sets up the plumbing for fetching indicator data asynchronously. Some notes:
* A data source is defined in a single file by implementing several javascript functions that adapt the data source's response to the visualization implementations used in the platform
* A loading indicator (spinner) is shown on visualizations while data is being loaded
* The [local_csv data source](https://github.com/brockfanning/sdg-indicators/blob/external-data-runtime/_includes/indicator_data_source/local_csv.html) is provided, and implemented without ajax, so that the default CSV behavior will not have any noticeable load time
* Each visualization is changed from immediately executed javascript to a function that is called by a custom event, which itself is triggered when the data source responds
* Each indicator will default to the provided "local_csv" data source, but that can be overridden in the frontmatter with `indicator_data_source`.