### PR TITLE
Use english URLs for goal links on frontpage.

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -37,6 +37,15 @@
 
                     {% for goals in sdg_goals %}
 
+                    {% assign english_goal = goals %}
+                    {% if page.lang != 'en' %}
+                        {% for untranslated_goal in site.data.sdg_goals %}
+                            {% if untranslated_goal.goal == goals.goal %}
+                                {% assign english_goal = untranslated_goal %}
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
+
                     {% assign img_path = goals.goal | plus:0 %}
 
                     {% if img_path < 10 %}
@@ -46,7 +55,7 @@
                     {% endif %}
 
 
-                    <a class="usa-width-one-fourth" href="../{{ goals.short | slugify }}/">
+                    <a class="usa-width-one-fourth" href="../{{ english_goal.short | slugify }}/">
                     <img class="goal-icon" src="{{ site.baseurl }}/assets/img/{{ page.lang }}/{{ page.lang }}-sdg-goal-{{ img_path }}{{ goals.goal }}.png" alt="icon for Goal {{ goals.goal }} - {{ goals.title }}" />
                     </a>                    
 


### PR DESCRIPTION
This should fix the 404s for the goal links on the non-English frontpages. Fixes #929 