### PR TITLE
Do not add visualization javascript unless there is a graph type set.

### DIFF
--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -213,7 +213,9 @@
 
 {% include scripts.html %}
 
+{%- if page.graph -%}
 {% include indicator_data_source/base.html graph_type=graph_type %}
 {% include indicator_data_source/{{ page.indicator_data_source }}.html graph_type=graph_type %}
+{%- endif -%}
     
 {% include footer.html %}


### PR DESCRIPTION
If an indicator has no graph type set, this javascript runs and encounters and error. This adds a conditional to prevent that from happening.