### PR TITLE
Tweak some tier-3 indicators to disguise their tier-3-ness

### DIFF
--- a/_indicators/17-13-1.md
+++ b/_indicators/17-13-1.md
@@ -10,7 +10,7 @@ graph_type_description: null
 graph_status_notes: unk
 variable_description: null
 variable_notes: null
-un_designated_tier: '3'
+un_designated_tier: '3 (data available)'
 un_custodial_agency: World Bank
 target_id: '17.13'
 has_metadata: false

--- a/_indicators/4-2-1.md
+++ b/_indicators/4-2-1.md
@@ -12,7 +12,7 @@ graph_type_description: Bar graph
 graph_status_notes: Graphed
 variable_description: null
 variable_notes: null
-un_designated_tier: '3'
+un_designated_tier: '3 (data available)'
 un_custodial_agency: 'UNICEF (Partnering Agencies: UNESCO-UIS, OECD)'
 target_id: '4.2'
 has_metadata: true

--- a/_indicators/4-7-1.md
+++ b/_indicators/4-7-1.md
@@ -14,7 +14,7 @@ graph_type_description: Bar graph
 graph_status_notes: Graphed
 variable_description: null
 variable_notes: null
-un_designated_tier: '3'
+un_designated_tier: '3 (data available)'
 un_custodial_agency: 'UNESCO-UIS (Partnering Agencies: OECD, UNEP, UN Women)'
 target_id: '4.7'
 has_metadata: true

--- a/_indicators/8-9-2.md
+++ b/_indicators/8-9-2.md
@@ -10,7 +10,7 @@ graph_type_description: BLS needs a defintion of tourism before it can report
 graph_status_notes: Checking
 variable_description: null
 variable_notes: null
-un_designated_tier: '2 '
+un_designated_tier: '3 (data available)'
 un_custodial_agency: UNWTO
 target_id: '8.9'
 has_metadata: true


### PR DESCRIPTION
Tweak the tier value of some tier-3 indicators to make the platform treat them like non-tier-3 indicators. This is a quick fix -- a longer-term solution will involve changes to the goal and status layouts.