### PR TITLE
Remove dots from column names in 17-6-2.

### DIFF
--- a/data/indicator_17-6-2.csv
+++ b/data/indicator_17-6-2.csv
@@ -1,4 +1,4 @@
-year,200_kbps_lt_1.5_mbps_sbscrptns,1.5_mbps_lt_10_mbps_sbscriptns,10_mbps_gr_sbscrpts
+year,200_kbps_lt_1-5_mbps_sbscrptns,1-5_mbps_lt_10_mbps_sbscriptns,10_mbps_gr_sbscrpts
 2000,,,
 2001,,,
 2002,,,


### PR DESCRIPTION
This should prevent the javascript alert message thrown by the Datatables library, which apparently doesn't like dots being in the CSV column names.